### PR TITLE
end cautionary alert activity history

### DIFF
--- a/src/components/activity-history-list/activity-history-list.spec.tsx
+++ b/src/components/activity-history-list/activity-history-list.spec.tsx
@@ -16,6 +16,7 @@ import {
   mockCreatedPhoneNumberWithContactTypeAsString,
   mockCreatedTenure,
   mockEdittedTenureWithInValidParam,
+  mockEndedCautionaryAlert,
   mockEqualityData,
   mockMigratedPerson,
   mockMigratedPersonEqualityInformation,
@@ -737,4 +738,16 @@ test("it should display a row for created cautionary alert", async () => {
   await expect(
     screen.findByText(/Cautionary Alert created/),
   ).resolves.toBeInTheDocument();
+});
+
+test("it should display a row for ended cautionary alert", async () => {
+  get("/api/activityhistory", {
+    results: [mockEndedCautionaryAlert],
+    paginationDetails: {
+      nextToken: null,
+    },
+  });
+  routeRender(<ActivityHistoryList targetId="123" entityType="person" />);
+
+  await expect(screen.findByText(/Cautionary Alert ended/)).resolves.toBeInTheDocument();
 });

--- a/src/components/activity-history-list/cautionary-alert-record/cautionarty-alert-record.tsx
+++ b/src/components/activity-history-list/cautionary-alert-record/cautionarty-alert-record.tsx
@@ -7,7 +7,7 @@ import { formattedDate } from "../utils";
 import { locale } from "@services";
 
 const { activities } = locale;
-const { entityCreated, entityEdited } = activities;
+const { entityCreated, entityEdited, entityEnded } = activities;
 
 interface CautionaryAlertActivityRecordProps
   extends Omit<ComponentPropsWithoutRef<"div">, "children"> {
@@ -42,6 +42,14 @@ export const CautionaryAlertActivityRecord = ({
             newData={newData}
           />
         );
+      case "end":
+        return (
+          <EndedCautionaryAlertRecord
+            targetType={targetType}
+            oldData={oldData}
+            newData={newData}
+          />
+        );
       default:
         return null;
     }
@@ -61,5 +69,11 @@ export const CautionaryAlertActivityRecord = ({
 const CreatedCautionaryAlertRecord = ({ targetType }: any): JSX.Element => (
   <p>
     <b>{entityCreated(targetType, "CautionaryAlert")}</b>
+  </p>
+);
+
+const EndedCautionaryAlertRecord = ({ targetType }: any): JSX.Element => (
+  <p>
+    <b>{entityEnded(targetType)}</b>
   </p>
 );

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -684,3 +684,15 @@ export const mockCreatedCautionaryAlert: Activity = {
   newData: {},
   authorDetails: { id: "", fullName: "Jane", email: "email@email.com" },
 };
+
+export const mockEndedCautionaryAlert: Activity = {
+  id: "cd2e0e18-d675-225b-7c48-4df00fbb7971",
+  targetId: "81cbaf65-096a-fa76-cb40-6085b54b9033",
+  type: "end",
+  targetType: "cautionaryAlert",
+  createdAt: "2021-10-29T07:15:11",
+  timeToLiveForRecordInDays: 0,
+  oldData: null,
+  newData: {},
+  authorDetails: { id: "", fullName: "Jane", email: "email@email.com" },
+};

--- a/src/services/activities/activities.types.ts
+++ b/src/services/activities/activities.types.ts
@@ -3,7 +3,7 @@ import { Person } from "@mtfh/common/lib/api/person/v1";
 import { ReferenceData } from "@mtfh/common/lib/api/reference-data/v1";
 import { HouseholdMember } from "@mtfh/common/lib/api/tenure/v1";
 
-export type ActivityType = "create" | "update" | "delete" | "migrate";
+export type ActivityType = "create" | "update" | "delete" | "migrate" | "end";
 export type ActivityTargetType =
   | "process"
   | "person"

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -51,6 +51,8 @@ const locale = {
       `${locale.activities.targetType[type]} migrated`,
     entityEdited: (type: ActivityTargetType): string =>
       `Edit to ${locale.activities.targetType[type].toLowerCase()}`,
+    entityEnded: (type: ActivityTargetType): string =>
+      `${locale.activities.targetType[type]} ended`,
     personAddedToTenure: "Person added to tenure",
     personRemovedFromTenure: "Person removed from tenure",
     personAddedDetailsTitle: "New person created with the following details:",


### PR DESCRIPTION
As part of the End Cautionary Alert functionality, one of the requirements is to add an Activity History every time a CA is ended. This PR should show the Activity History for CA ended and relevant tests have been added. 