### PR TITLE
Add Property Activity History

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@hackney/mtfh-test-utils": "^1.6.0",
-    "@mtfh/common": "https://github.com/LBHackney-IT/mtfh-frontend-common.git#9460ed44db8dff88f686cd8a776b09f1aae02adf",
+    "@mtfh/common": "https://github.com/LBHackney-IT/mtfh-frontend-common.git",
     "@types/jest": "^26.0.16",
     "@types/react": "17.0.20",
     "@types/react-dom": "^16.9.6",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@hackney/mtfh-test-utils": "^1.6.0",
-    "@mtfh/common": "https://github.com/LBHackney-IT/mtfh-frontend-common.git",
+    "@mtfh/common": "https://github.com/LBHackney-IT/mtfh-frontend-common.git#9460ed44db8dff88f686cd8a776b09f1aae02adf",
     "@types/jest": "^26.0.16",
     "@types/react": "17.0.20",
     "@types/react-dom": "^16.9.6",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import { Route, Switch } from "react-router-dom";
 
 import { ActivitiesPersonView } from "./views/activities-person-view";
 import { ActivitiesProcessView } from "./views/activities-process-view";
+import { ActivitiesPropertyView } from "./views/activities-property-view";
 import { ActivitiesTenureView } from "./views/activities-tenure-view";
 
 export default function App(): JSX.Element {
@@ -16,6 +17,9 @@ export default function App(): JSX.Element {
       </Route>
       <Route path="/activities/process/:processName/:id" exact>
         <ActivitiesProcessView entityType="process" />
+      </Route>
+      <Route path="/activities/property/:id" exact>
+        <ActivitiesPropertyView entityType="property" />
       </Route>
       <Route path="*">404</Route>
     </Switch>

--- a/src/components/activity-history-list/activity-history-list.spec.tsx
+++ b/src/components/activity-history-list/activity-history-list.spec.tsx
@@ -29,6 +29,7 @@ import {
   mockUpdatedFirstName,
   mockUpdatedIdentifications,
   mockUpdatedLanguages,
+  mockUpdatedPatchesAndAreas,
   mockUpdatedPersonEqualityInformation,
   mockUpdatedPlaceOfBirth,
   mockUpdatedTenure,
@@ -750,4 +751,18 @@ test("it should display a row for ended cautionary alert", async () => {
   routeRender(<ActivityHistoryList targetId="123" entityType="person" />);
 
   await expect(screen.findByText(/Cautionary Alert ended/)).resolves.toBeInTheDocument();
+});
+
+test("it should display a row for updated patches and areas", async () => {
+  get("/api/activityhistory", {
+    results: [mockUpdatedPatchesAndAreas],
+    paginationDetails: {
+      nextToken: null,
+    },
+  });
+  routeRender(<ActivityHistoryList targetId="123" entityType="person" />);
+
+  await expect(
+    screen.findByText(/Edit to patches and areas/),
+  ).resolves.toBeInTheDocument();
 });

--- a/src/components/activity-history-list/activity-history-list.spec.tsx
+++ b/src/components/activity-history-list/activity-history-list.spec.tsx
@@ -762,7 +762,18 @@ test("it should display a row for updated patches and areas", async () => {
   });
   routeRender(<ActivityHistoryList targetId="123" entityType="property" />);
 
-  await expect(
-    screen.findByText(/Edit to patches and areas/),
-  ).resolves.toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.findByText(mockUpdatedPatchesAndAreas.oldData?.name),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.findByText(mockUpdatedPatchesAndAreas.oldData?.contactDetails?.emailAddress),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.findByText(mockUpdatedPatchesAndAreas.newData?.name),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.findByText(mockUpdatedPatchesAndAreas.newData?.contactDetails?.emailAddress),
+    ).resolves.toBeInTheDocument();
+  });
 });

--- a/src/components/activity-history-list/activity-history-list.spec.tsx
+++ b/src/components/activity-history-list/activity-history-list.spec.tsx
@@ -760,7 +760,7 @@ test("it should display a row for updated patches and areas", async () => {
       nextToken: null,
     },
   });
-  routeRender(<ActivityHistoryList targetId="123" entityType="person" />);
+  routeRender(<ActivityHistoryList targetId="123" entityType="property" />);
 
   await expect(
     screen.findByText(/Edit to patches and areas/),

--- a/src/components/activity-history-list/activity-history-list.tsx
+++ b/src/components/activity-history-list/activity-history-list.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from "react";
 import { ActivityHistoryHeaders } from "./activity-history-headers";
 import { CautionaryAlertActivityRecord } from "./cautionary-alert-record";
 import { ContactDetailsActivityRecord } from "./contact-details-record";
+import { PatchesAndAreasActivityRecord } from "./patches-and-areas-record";
 import { PersonEqualityInformationActivityRecord } from "./person-equality-information-record";
 import { PersonActivityRecord } from "./person-record";
 import { ProcessActivityRecord } from "./process-record";
@@ -23,7 +24,6 @@ import {
 import { EntityType, locale, useActivityHistory } from "@services";
 
 import "./activity-history-list.styles.scss";
-import { PatchesAndAreasActivityRecord } from "./patches-and-areas-record";
 
 const { noActivityHistory } = locale.activities;
 

--- a/src/components/activity-history-list/activity-history-list.tsx
+++ b/src/components/activity-history-list/activity-history-list.tsx
@@ -23,6 +23,7 @@ import {
 import { EntityType, locale, useActivityHistory } from "@services";
 
 import "./activity-history-list.styles.scss";
+import { PatchesAndAreasActivityRecord } from "./patches-and-areas-record";
 
 const { noActivityHistory } = locale.activities;
 
@@ -126,6 +127,14 @@ export const ActivityHistoryList = ({
                 <CautionaryAlertActivityRecord
                   key={index}
                   cautionaryAlertRecord={activity}
+                />
+              );
+            }
+            if (targetType === "patchesAndAreas") {
+              return (
+                <PatchesAndAreasActivityRecord
+                  key={index}
+                  patchesAndAreasRecord={activity}
                 />
               );
             }

--- a/src/components/activity-history-list/index.ts
+++ b/src/components/activity-history-list/index.ts
@@ -6,3 +6,4 @@ export * from "./tenure-record";
 export * from "./tenure-person-record";
 export * from "./utils";
 export * from "./cautionary-alert-record";
+export * from "./patches-and-areas-record";

--- a/src/components/activity-history-list/patches-and-areas-record/index.ts
+++ b/src/components/activity-history-list/patches-and-areas-record/index.ts
@@ -1,0 +1,1 @@
+export * from "./patches-and-areas-record";

--- a/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
+++ b/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
@@ -1,0 +1,65 @@
+import React, { ComponentPropsWithoutRef, useMemo } from "react";
+
+import { Activity } from "../../../services/activities";
+import { ActivityRecordItem } from "../activity-record-item";
+import { formattedDate } from "../utils";
+
+import { locale } from "@services";
+
+const { activities } = locale;
+const { entityCreated, entityEdited } = activities;
+
+interface PatchesAndAreasActivityRecordProps
+  extends Omit<ComponentPropsWithoutRef<"div">, "children"> {
+  patchesAndAreasRecord: Activity;
+}
+
+export const PatchesAndAreasActivityRecord = ({
+  patchesAndAreasRecord,
+  ...props
+}: PatchesAndAreasActivityRecordProps): JSX.Element | null => {
+  const {
+    oldData: oldDataActivity,
+    newData: newDataActivty,
+    type,
+    targetType,
+  } = patchesAndAreasRecord;
+
+  const oldData = useMemo(() => oldDataActivity || {}, [oldDataActivity]);
+  const newData = useMemo(() => newDataActivty || {}, [newDataActivty]);
+
+  const date = formattedDate(patchesAndAreasRecord.createdAt);
+  const category = entityEdited(patchesAndAreasRecord.targetType);
+  const edittedBy = patchesAndAreasRecord.authorDetails.fullName;
+
+  const activityRecord = useMemo(() => {
+    switch (type) {
+      case "update":
+        return (
+          <UpdatedPatchesAndAreasRecord
+            targetType={targetType}
+            oldData={oldData}
+            newData={newData}
+          />
+        );
+      default:
+        return null;
+    }
+  }, [type, targetType, oldData, newData]);
+
+  return (
+    <ActivityRecordItem
+      {...props}
+      date={date}
+      category={category}
+      editDetails={activityRecord}
+      editedBy={edittedBy}
+    />
+  );
+};
+
+const UpdatedPatchesAndAreasRecord = ({ targetType }: any): JSX.Element => (
+  <p>
+    <b>{entityEdited(targetType)}</b>
+  </p>
+);

--- a/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
+++ b/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
@@ -1,9 +1,6 @@
 import React, { ComponentPropsWithoutRef, useMemo } from "react";
 
-import {
-  Activity,
-  PatchResponsibilityEntityActivityData,
-} from "../../../services/activities";
+import { Activity } from "../../../services/activities";
 import { ActivityRecordItem } from "../activity-record-item";
 import { formattedDate } from "../utils";
 
@@ -17,20 +14,6 @@ interface PatchesAndAreasActivityRecordProps
   patchesAndAreasRecord: Activity;
 }
 
-// const filterProperties = (data?: PatchResponsibilityEntityActivityData | null) => {
-//   if (!data) return {};
-//   const {
-//     name,
-//     responsibleType,
-//     contactDetails,
-//   } = data;
-//   return {
-//     name,
-//     responsibleType,
-//     contactDetails,
-//   };
-// };
-
 export const PatchesAndAreasActivityRecord = ({
   patchesAndAreasRecord,
   ...props
@@ -42,15 +25,6 @@ export const PatchesAndAreasActivityRecord = ({
     newData: newDataActivty,
   } = patchesAndAreasRecord;
 
-  // const oldData = useMemo(
-  //   () => filterProperties(oldDataActivity as PatchResponsibilityEntityActivityData),
-  //   [oldDataActivity],
-  // );
-  // const newData = useMemo(
-  //   () => filterProperties(newDataActivty as PatchResponsibilityEntityActivityData),
-  //   [newDataActivty],
-  // );
-
   const oldData = useMemo(() => oldDataActivity || {}, [oldDataActivity]);
   const newData = useMemo(() => newDataActivty || {}, [newDataActivty]);
 
@@ -61,10 +35,9 @@ export const PatchesAndAreasActivityRecord = ({
   const activityRecord = useMemo(() => {
     switch (type) {
       case "update":
-        console.log("targetType: " + targetType);
         return (
           <UpdatedPatchesAndAreasRecord
-            targetType="patchesAndAreas"
+            targetType={targetType}
             oldData={oldData}
             newData={newData}
           />
@@ -85,11 +58,6 @@ export const PatchesAndAreasActivityRecord = ({
   );
 };
 
-interface UpdatedPatchesAndAreasRecordProps {
-  targetType: string;
-  oldData: PatchResponsibilityEntityActivityData;
-  newData: PatchResponsibilityEntityActivityData;
-}
 const UpdatedPatchesAndAreasRecord = ({
   targetType,
   oldData,

--- a/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
+++ b/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
@@ -1,6 +1,9 @@
 import React, { ComponentPropsWithoutRef, useMemo } from "react";
 
-import { Activity } from "../../../services/activities";
+import {
+  Activity,
+  PatchResponsibilityEntityActivityData,
+} from "../../../services/activities";
 import { ActivityRecordItem } from "../activity-record-item";
 import { formattedDate } from "../utils";
 
@@ -14,16 +17,39 @@ interface PatchesAndAreasActivityRecordProps
   patchesAndAreasRecord: Activity;
 }
 
+// const filterProperties = (data?: PatchResponsibilityEntityActivityData | null) => {
+//   if (!data) return {};
+//   const {
+//     name,
+//     responsibleType,
+//     contactDetails,
+//   } = data;
+//   return {
+//     name,
+//     responsibleType,
+//     contactDetails,
+//   };
+// };
+
 export const PatchesAndAreasActivityRecord = ({
   patchesAndAreasRecord,
   ...props
 }: PatchesAndAreasActivityRecordProps): JSX.Element | null => {
   const {
-    oldData: oldDataActivity,
-    newData: newDataActivty,
     type,
     targetType,
+    oldData: oldDataActivity,
+    newData: newDataActivty,
   } = patchesAndAreasRecord;
+
+  // const oldData = useMemo(
+  //   () => filterProperties(oldDataActivity as PatchResponsibilityEntityActivityData),
+  //   [oldDataActivity],
+  // );
+  // const newData = useMemo(
+  //   () => filterProperties(newDataActivty as PatchResponsibilityEntityActivityData),
+  //   [newDataActivty],
+  // );
 
   const oldData = useMemo(() => oldDataActivity || {}, [oldDataActivity]);
   const newData = useMemo(() => newDataActivty || {}, [newDataActivty]);
@@ -35,9 +61,10 @@ export const PatchesAndAreasActivityRecord = ({
   const activityRecord = useMemo(() => {
     switch (type) {
       case "update":
+        console.log("targetType: " + targetType);
         return (
           <UpdatedPatchesAndAreasRecord
-            targetType={targetType}
+            targetType="patchesAndAreas"
             oldData={oldData}
             newData={newData}
           />
@@ -58,8 +85,21 @@ export const PatchesAndAreasActivityRecord = ({
   );
 };
 
-const UpdatedPatchesAndAreasRecord = ({ targetType }: any): JSX.Element => (
-  <p>
+interface UpdatedPatchesAndAreasRecordProps {
+  targetType: string;
+  oldData: PatchResponsibilityEntityActivityData;
+  newData: PatchResponsibilityEntityActivityData;
+}
+const UpdatedPatchesAndAreasRecord = ({
+  targetType,
+  oldData,
+  newData,
+}: any): JSX.Element => (
+  <>
     <b>{entityEdited(targetType)}</b>
-  </p>
+    <p>Old Name: {oldData?.name}</p>
+    <p>Old Email: {oldData?.contactDetails?.emailAddress}</p>
+    <p>New Name: {newData?.name}</p>
+    <p>New Email: {newData?.contactDetails?.emailAddress}</p>
+  </>
 );

--- a/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
+++ b/src/components/activity-history-list/patches-and-areas-record/patches-and-areas-record.tsx
@@ -7,7 +7,7 @@ import { formattedDate } from "../utils";
 import { locale } from "@services";
 
 const { activities } = locale;
-const { entityCreated, entityEdited } = activities;
+const { entityEdited } = activities;
 
 interface PatchesAndAreasActivityRecordProps
   extends Omit<ComponentPropsWithoutRef<"div">, "children"> {

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -704,7 +704,21 @@ export const mockUpdatedPatchesAndAreas: Activity = {
   targetType: "patchesAndAreas",
   createdAt: "2023-10-23T07:15:11",
   timeToLiveForRecordInDays: 0,
-  oldData: null,
-  newData: {},
+  oldData: {
+    name: "FAKE_TESTER FAKE_TESTING",
+    responsibleType: "HousingOfficer",
+    id: "9efa7ed3-6e09-4fbe-b99b-f77b8535e909",
+    contactDetails: {
+      emailAddress: "tester.testing@hackney.gov.uk",
+    },
+  },
+  newData: {
+    name: "FAKE_JANE FAKE_DOE",
+    responsibleType: "HousingOfficer",
+    id: "9efa7ed3-6e09-4fbe-b99b-f77b8535e909",
+    contactDetails: {
+      emailAddress: "tester.testing@hackney.gov.uk",
+    },
+  },
   authorDetails: { id: "", fullName: "Jane", email: "email@email.com" },
 };

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -696,3 +696,15 @@ export const mockEndedCautionaryAlert: Activity = {
   newData: {},
   authorDetails: { id: "", fullName: "Jane", email: "email@email.com" },
 };
+
+export const mockUpdatedPatchesAndAreas: Activity = {
+  id: "8aa5b9ca-b1d0-46d4-9008-7153eb854214",
+  targetId: "d2d400c6-f31c-4db5-be18-87dedcf760d7",
+  type: "update",
+  targetType: "patchesAndAreas",
+  createdAt: "2023-10-23T07:15:11",
+  timeToLiveForRecordInDays: 0,
+  oldData: null,
+  newData: {},
+  authorDetails: { id: "", fullName: "Jane", email: "email@email.com" },
+};

--- a/src/services/activities/activities.types.ts
+++ b/src/services/activities/activities.types.ts
@@ -1,5 +1,4 @@
 import { EqualityData } from "@mtfh/common/lib/api/equality-information/v1";
-import { ResponsibleEntity } from "@mtfh/common/lib/api/patch/v1";
 import { Person } from "@mtfh/common/lib/api/person/v1";
 import { ReferenceData } from "@mtfh/common/lib/api/reference-data/v1";
 import { HouseholdMember } from "@mtfh/common/lib/api/tenure/v1";
@@ -34,14 +33,12 @@ export type TenurePersonActivityData = {
 export type ProcessActivityData = {
   processData: any;
 };
-export type PatchResponsibilityEntityActivityData = Partial<Nullable<ResponsibleEntity>>;
 
 export type ActivityData = (
   | PersonEqualityDataActivityData
   | PersonActivityData
   | TenurePersonActivityData
   | ProcessActivityData
-  | PatchResponsibilityEntityActivityData
 ) & {
   [key: string]: any;
 };

--- a/src/services/activities/activities.types.ts
+++ b/src/services/activities/activities.types.ts
@@ -1,4 +1,5 @@
 import { EqualityData } from "@mtfh/common/lib/api/equality-information/v1";
+import { ResponsibleEntity } from "@mtfh/common/lib/api/patch/v1";
 import { Person } from "@mtfh/common/lib/api/person/v1";
 import { ReferenceData } from "@mtfh/common/lib/api/reference-data/v1";
 import { HouseholdMember } from "@mtfh/common/lib/api/tenure/v1";
@@ -33,12 +34,14 @@ export type TenurePersonActivityData = {
 export type ProcessActivityData = {
   processData: any;
 };
+export type PatchResponsibilityEntityActivityData = Partial<Nullable<ResponsibleEntity>>;
 
 export type ActivityData = (
   | PersonEqualityDataActivityData
   | PersonActivityData
   | TenurePersonActivityData
   | ProcessActivityData
+  | PatchResponsibilityEntityActivityData
 ) & {
   [key: string]: any;
 };

--- a/src/services/activities/activities.types.ts
+++ b/src/services/activities/activities.types.ts
@@ -12,7 +12,8 @@ export type ActivityTargetType =
   | "contactDetails"
   | "tenurePerson"
   | "personEqualityInformation"
-  | "cautionaryAlert";
+  | "cautionaryAlert"
+  | "patchesAndAreas";
 
 export type EntityType = "person" | "tenure" | "process";
 export type ActivityProcessName = "soletojoint";

--- a/src/services/activities/activities.types.ts
+++ b/src/services/activities/activities.types.ts
@@ -15,7 +15,7 @@ export type ActivityTargetType =
   | "cautionaryAlert"
   | "patchesAndAreas";
 
-export type EntityType = "person" | "tenure" | "process";
+export type EntityType = "person" | "tenure" | "process" | "property";
 export type ActivityProcessName = "soletojoint";
 
 interface AuthorDetails {

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -14,6 +14,7 @@ import {
 import { Identification, Language } from "@mtfh/common/lib/api/person/v1";
 import { ReferenceData } from "@mtfh/common/lib/api/reference-data/v1";
 import { TenureType } from "@mtfh/common/lib/api/tenure/v1";
+import { ResponsibleEntity } from "@mtfh/common/lib/api/patch/v1";
 
 const locale = {
   activities: {

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -14,7 +14,6 @@ import {
 import { Identification, Language } from "@mtfh/common/lib/api/person/v1";
 import { ReferenceData } from "@mtfh/common/lib/api/reference-data/v1";
 import { TenureType } from "@mtfh/common/lib/api/tenure/v1";
-import { ResponsibleEntity } from "@mtfh/common/lib/api/patch/v1";
 
 const locale = {
   activities: {

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -41,6 +41,7 @@ const locale = {
       tenurePerson: "Person",
       personEqualityInformation: "Equality information",
       cautionaryAlert: "Cautionary Alert",
+      patchesAndAreas: "Patches and Areas",
     },
     entityCreated: (type: ActivityTargetType, sourceDomain: string): string => {
       return sourceDomain === "Processes"

--- a/src/views/activities-property-view/__snapshots__/activities-property-view.test.tsx.snap
+++ b/src/views/activities-property-view/__snapshots__/activities-property-view.test.tsx.snap
@@ -2,76 +2,46 @@
 
 exports[`renders the activities view 1`] = `
 <div>
-  <div
-    data-testid="property-activities"
+  <svg
+    class="mtfh-icon"
+    focusable="false"
+    height="50"
+    stroke="#00703c"
+    viewBox="0 0 42 42"
+    width="50"
   >
-    <a
-      class="govuk-back-link lbh-back-link lbh-link--no-visited-state"
-      href="/property/undefined"
+    <title>
+      Loading...
+    </title>
+    <g
+      fill="none"
+      fill-rule="evenodd"
     >
-       
-    </a>
-    <h1
-      class="lbh-heading-h1"
-    >
-      Activity history
-    </h1>
-    <h2
-      class="lbh-heading-h2"
-    >
-       
-    </h2>
-    <div
-      class="mtfh-center mtfh-center--horizontal mtfh-center--vertical"
-    >
-      <svg
-        class="mtfh-icon"
-        focusable="false"
-        height="50"
-        stroke="#00703c"
-        viewBox="0 0 42 42"
-        width="50"
+      <g
+        stroke-width="5"
+        transform="translate(3 3)"
       >
-        <title>
-          Loading...
-        </title>
-        <g
-          fill="none"
-          fill-rule="evenodd"
+        <circle
+          cx="18"
+          cy="18"
+          r="18"
+          stroke-opacity=".5"
+        />
+        <path
+          d="M36 18c0-9.94-8.06-18-18-18"
+          transform="rotate(112.708 18 18)"
         >
-          <g
-            stroke-width="5"
-            transform="translate(3 3)"
-          >
-            <circle
-              cx="18"
-              cy="18"
-              r="18"
-              stroke-opacity=".5"
-            />
-            <path
-              d="M36 18c0-9.94-8.06-18-18-18"
-              transform="rotate(112.708 18 18)"
-            >
-              <animatetransform
-                attributeName="transform"
-                dur="1s"
-                from="0 18 18"
-                repeatCount="indefinite"
-                to="360 18 18"
-                type="rotate"
-              />
-            </path>
-          </g>
-        </g>
-      </svg>
-    </div>
-    <a
-      class="govuk-button lbh-button govuk-button--secondary lbh-button--secondary"
-      href="/property/undefined"
-    >
-      Close activity history
-    </a>
-  </div>
+          <animatetransform
+            attributeName="transform"
+            dur="1s"
+            from="0 18 18"
+            repeatCount="indefinite"
+            to="360 18 18"
+            type="rotate"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
 </div>
 `;

--- a/src/views/activities-property-view/__snapshots__/activities-property-view.test.tsx.snap
+++ b/src/views/activities-property-view/__snapshots__/activities-property-view.test.tsx.snap
@@ -1,0 +1,77 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders the activities view 1`] = `
+<div>
+  <div
+    data-testid="property-activities"
+  >
+    <a
+      class="govuk-back-link lbh-back-link lbh-link--no-visited-state"
+      href="/property/undefined"
+    >
+       
+    </a>
+    <h1
+      class="lbh-heading-h1"
+    >
+      Activity history
+    </h1>
+    <h2
+      class="lbh-heading-h2"
+    >
+       
+    </h2>
+    <div
+      class="mtfh-center mtfh-center--horizontal mtfh-center--vertical"
+    >
+      <svg
+        class="mtfh-icon"
+        focusable="false"
+        height="50"
+        stroke="#00703c"
+        viewBox="0 0 42 42"
+        width="50"
+      >
+        <title>
+          Loading...
+        </title>
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <g
+            stroke-width="5"
+            transform="translate(3 3)"
+          >
+            <circle
+              cx="18"
+              cy="18"
+              r="18"
+              stroke-opacity=".5"
+            />
+            <path
+              d="M36 18c0-9.94-8.06-18-18-18"
+              transform="rotate(112.708 18 18)"
+            >
+              <animatetransform
+                attributeName="transform"
+                dur="1s"
+                from="0 18 18"
+                repeatCount="indefinite"
+                to="360 18 18"
+                type="rotate"
+              />
+            </path>
+          </g>
+        </g>
+      </svg>
+    </div>
+    <a
+      class="govuk-button lbh-button govuk-button--secondary lbh-button--secondary"
+      href="/property/undefined"
+    >
+      Close activity history
+    </a>
+  </div>
+</div>
+`;

--- a/src/views/activities-property-view/activities-property-view.test.tsx
+++ b/src/views/activities-property-view/activities-property-view.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { screen, waitFor } from "@testing-library/react";
+
+import { routeRender } from "../../test-utils";
+
+import { ActivitiesPropertyView } from ".";
+
+import { locale } from "@services";
+
+test("renders the activities view", async () => {
+  const [{ container }] = routeRender(<ActivitiesPropertyView entityType="property" />, {
+    url: "/activities/property/123",
+  });
+  expect(container).toMatchSnapshot();
+
+  await waitFor(() =>
+    expect(screen.getAllByRole("heading")[0]).toHaveTextContent(
+      locale.activities.pageTitle,
+    ),
+  );
+});

--- a/src/views/activities-property-view/activities-property-view.test.tsx
+++ b/src/views/activities-property-view/activities-property-view.test.tsx
@@ -7,10 +7,12 @@ import { routeRender } from "../../test-utils";
 import { ActivitiesPropertyView } from ".";
 
 import { locale } from "@services";
+import { mockUpdatedPatchesAndAreas } from "../../mocks/data";
 
 test("renders the activities view", async () => {
+  const id = mockUpdatedPatchesAndAreas.id;
   const [{ container }] = routeRender(<ActivitiesPropertyView entityType="property" />, {
-    url: "/activities/property/123",
+    url: `/activities/property/${id}`,
   });
   expect(container).toMatchSnapshot();
 

--- a/src/views/activities-property-view/activities-property-view.test.tsx
+++ b/src/views/activities-property-view/activities-property-view.test.tsx
@@ -1,19 +1,77 @@
 import React from "react";
 
+import { mockAssetV1, render, server } from "@hackney/mtfh-test-utils";
 import { screen, waitFor } from "@testing-library/react";
-
-import { routeRender } from "../../test-utils";
+import { rest } from "msw";
 
 import { ActivitiesPropertyView } from ".";
 
+import * as auth from "@mtfh/common/lib/auth/auth";
+
 import { locale } from "@services";
-import { mockUpdatedPatchesAndAreas } from "../../mocks/data";
+
+const assetData = {
+  id: "15adc44b-6fde-46e8-af9c-e18b1495c9ab",
+  assetId: "100021045676",
+  areaId: "7c9790a5-ea4d-4819-bcdb-0a10094b7166",
+  patchId: "a6809b57-9ba9-4a7d-bf14-f3a1182ca994",
+  assetType: "LettableNonDwelling",
+  rootAsset: null,
+  parentAssetIds: null,
+  isActive: false,
+  assetLocation: null,
+  assetAddress: {
+    uprn: "100021045676",
+    addressLine1: "51 GREENWOOD ROAD - FLAT B",
+    addressLine2: "",
+    addressLine3: "",
+    addressLine4: "",
+    postCode: "E8 1QT",
+    postPreamble: "X",
+  },
+  assetManagement: {
+    agent: null,
+    areaOfficeName: null,
+    isCouncilProperty: false,
+    managingOrganisation: null,
+    managingOrganisationId: "00000000-0000-0000-0000-000000000000",
+    owner: null,
+    isTMOManaged: false,
+    propertyOccupiedStatus: null,
+    propertyOccupiedStatusReason: null,
+    isNoRepairsMaintenance: false,
+    councilTaxType: null,
+    councilTaxLiability: null,
+    isTemporaryAccomodation: true,
+    readyToLetDate: false,
+  },
+  assetCharacteristics: null,
+  tenure: {
+    id: "387ddd25-5b10-452d-ba44-1cfac0583075",
+    type: "Asylum Seeker",
+    startOfTenureDate: "2011-01-01T00:00:00Z",
+  },
+  versionNumber: 18,
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+
+  jest.spyOn(auth, "isAuthorisedForGroups").mockReturnValue(true);
+
+  server.use(
+    rest.get("/api/v1/assets/:id", (req, res, ctx) => {
+      return res(ctx.json(assetData));
+    }),
+  );
+});
 
 test("renders the activities view", async () => {
-  const id = mockUpdatedPatchesAndAreas.id;
-  const [{ container }] = routeRender(<ActivitiesPropertyView entityType="property" />, {
-    url: `/activities/property/${id}`,
+  const { container } = render(<ActivitiesPropertyView entityType="property" />, {
+    url: `/activities/property/${mockAssetV1.id}`,
+    path: "/activities/property/:id",
   });
+
   expect(container).toMatchSnapshot();
 
   await waitFor(() =>

--- a/src/views/activities-property-view/activities-property-view.tsx
+++ b/src/views/activities-property-view/activities-property-view.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Link as RouterLink, useParams } from "react-router-dom";
+
+import { Button, Link } from "@mtfh/common";
+import { useAsset } from "@mtfh/common/lib/api/asset/v1";
+
+import { ActivityHistoryList } from "@components";
+import { EntityType, locale } from "@services";
+
+const { pageTitle, closeButton } = locale.activities;
+
+export interface EntityRequestId {
+  id: string;
+}
+
+const PropertyInformation = ({ id }: EntityRequestId) => {
+  const { data: property } = useAsset(id);
+  return (
+    <>
+      <Link as={RouterLink} to={`/property/${id}`} variant="back-link">
+        {property?.assetAddress.addressLine1} {property?.assetAddress.postCode}
+      </Link>
+      <h1 className="lbh-heading-h1">{pageTitle}</h1>
+      <h2 className="lbh-heading-h2">
+        {property?.assetAddress.addressLine1} {property?.assetAddress.postCode}
+      </h2>
+    </>
+  );
+};
+
+export const ActivitiesPropertyView = ({
+  entityType,
+}: {
+  entityType: EntityType;
+}): JSX.Element => {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <div data-testid="property-activities">
+      <PropertyInformation id={id} />
+      <ActivityHistoryList targetId={id} entityType={entityType} />
+      <Button as={RouterLink} to={`/property/${id}`} variant="secondary">
+        {closeButton}
+      </Button>
+    </div>
+  );
+};

--- a/src/views/activities-property-view/activities-property-view.tsx
+++ b/src/views/activities-property-view/activities-property-view.tsx
@@ -2,30 +2,25 @@ import React from "react";
 import { Link as RouterLink, useParams } from "react-router-dom";
 
 import { Button, Link } from "@mtfh/common";
-import { useAsset } from "@mtfh/common/lib/api/asset/v1";
-import { getPatchOrAreaById } from "@mtfh/common/lib/api/patch/v1"
-
+import { Asset, useAsset } from "@mtfh/common/lib/api/asset/v1";
 import { ActivityHistoryList } from "@components";
 import { EntityType, locale } from "@services";
 
 const { pageTitle, closeButton } = locale.activities;
 
 export interface EntityRequestId {
-  id: string;
-  patchId: string;
+  asset: Asset;
 }
 
-const PropertyInformation = ({ id, patchId }: EntityRequestId) => {
-  const { data: property } = useAsset(id);
-  const {} = getPatchOrAreaById(patchId)
+const PropertyInformation = ({ asset }: EntityRequestId) => {
   return (
     <>
-      <Link as={RouterLink} to={`/property/${id}`} variant="back-link">
-        {property?.assetAddress.addressLine1} {property?.assetAddress.postCode}
+      <Link as={RouterLink} to={`/property/${asset.id}`} variant="back-link">
+        {asset?.assetAddress.addressLine1} {asset?.assetAddress.postCode}
       </Link>
       <h1 className="lbh-heading-h1">{pageTitle}</h1>
       <h2 className="lbh-heading-h2">
-        {property?.assetAddress.addressLine1} {property?.assetAddress.postCode}
+        {asset?.assetAddress.addressLine1} {asset?.assetAddress.postCode}
       </h2>
     </>
   );
@@ -36,14 +31,21 @@ export const ActivitiesPropertyView = ({
 }: {
   entityType: EntityType;
 }): JSX.Element => {
-  const { id } = useParams<{ id: string }>();
-  const {patchId} = useParams<{patchId: string}>();
+  const { id: assetPK } = useParams<{ id: string }>();
+  const { data: asset } = useAsset(assetPK);
+  var patches = asset?.patches;
+  if(!asset || !patches || patches?.length == 0 )
+  {
+    console.log(`property patches empty ${patches}`)
+    return <h1>No activity history</h1>
+  }
+  const patchId = patches[0].id
 
   return (
     <div data-testid="property-activities">
-      <PropertyInformation id={id} patchId={patchId}/>
+      <PropertyInformation asset={asset} />
       <ActivityHistoryList targetId={patchId} entityType={entityType} />
-      <Button as={RouterLink} to={`/property/${id}`} variant="secondary">
+      <Button as={RouterLink} to={`/property/${assetPK}`} variant="secondary">
         {closeButton}
       </Button>
     </div>

--- a/src/views/activities-property-view/activities-property-view.tsx
+++ b/src/views/activities-property-view/activities-property-view.tsx
@@ -3,9 +3,10 @@ import { Link as RouterLink, useParams } from "react-router-dom";
 
 import { Button, Link } from "@mtfh/common";
 import { Asset, useAsset } from "@mtfh/common/lib/api/asset/v1";
+import { Spinner } from "@mtfh/common/lib/components";
+
 import { ActivityHistoryList } from "@components";
 import { EntityType, locale } from "@services";
-import { Spinner } from "@mtfh/common/lib/components";
 
 const { pageTitle, closeButton } = locale.activities;
 
@@ -34,12 +35,9 @@ export const ActivitiesPropertyView = ({
 }): JSX.Element => {
   const { id: assetPK } = useParams<{ id: string }>();
   const { data: asset } = useAsset(assetPK);
-  console.log("ASSET L37 : " + asset);
   if (!asset) {
     return <Spinner />;
   }
-
-  console.log("ASSET: " + asset);
 
   return (
     <div data-testid="property-activities">

--- a/src/views/activities-property-view/activities-property-view.tsx
+++ b/src/views/activities-property-view/activities-property-view.tsx
@@ -5,6 +5,7 @@ import { Button, Link } from "@mtfh/common";
 import { Asset, useAsset } from "@mtfh/common/lib/api/asset/v1";
 import { ActivityHistoryList } from "@components";
 import { EntityType, locale } from "@services";
+import { Spinner } from "@mtfh/common/lib/components";
 
 const { pageTitle, closeButton } = locale.activities;
 
@@ -33,18 +34,17 @@ export const ActivitiesPropertyView = ({
 }): JSX.Element => {
   const { id: assetPK } = useParams<{ id: string }>();
   const { data: asset } = useAsset(assetPK);
-  var patches = asset?.patches;
-  if(!asset || !patches || patches?.length == 0 )
-  {
-    console.log(`property patches empty ${patches}`)
-    return <h1>No activity history</h1>
+  console.log("ASSET L37 : " + asset);
+  if (!asset) {
+    return <Spinner />;
   }
-  const patchId = patches[0].id
+
+  console.log("ASSET: " + asset);
 
   return (
     <div data-testid="property-activities">
       <PropertyInformation asset={asset} />
-      <ActivityHistoryList targetId={patchId} entityType={entityType} />
+      <ActivityHistoryList targetId={asset.patchId} entityType={entityType} />
       <Button as={RouterLink} to={`/property/${assetPK}`} variant="secondary">
         {closeButton}
       </Button>

--- a/src/views/activities-property-view/activities-property-view.tsx
+++ b/src/views/activities-property-view/activities-property-view.tsx
@@ -3,6 +3,7 @@ import { Link as RouterLink, useParams } from "react-router-dom";
 
 import { Button, Link } from "@mtfh/common";
 import { useAsset } from "@mtfh/common/lib/api/asset/v1";
+import { getPatchOrAreaById } from "@mtfh/common/lib/api/patch/v1"
 
 import { ActivityHistoryList } from "@components";
 import { EntityType, locale } from "@services";
@@ -11,10 +12,12 @@ const { pageTitle, closeButton } = locale.activities;
 
 export interface EntityRequestId {
   id: string;
+  patchId: string;
 }
 
-const PropertyInformation = ({ id }: EntityRequestId) => {
+const PropertyInformation = ({ id, patchId }: EntityRequestId) => {
   const { data: property } = useAsset(id);
+  const {} = getPatchOrAreaById(patchId)
   return (
     <>
       <Link as={RouterLink} to={`/property/${id}`} variant="back-link">
@@ -34,11 +37,12 @@ export const ActivitiesPropertyView = ({
   entityType: EntityType;
 }): JSX.Element => {
   const { id } = useParams<{ id: string }>();
+  const {patchId} = useParams<{patchId: string}>();
 
   return (
     <div data-testid="property-activities">
-      <PropertyInformation id={id} />
-      <ActivityHistoryList targetId={id} entityType={entityType} />
+      <PropertyInformation id={id} patchId={patchId}/>
+      <ActivityHistoryList targetId={patchId} entityType={entityType} />
       <Button as={RouterLink} to={`/property/${id}`} variant="secondary">
         {closeButton}
       </Button>

--- a/src/views/activities-property-view/index.tsx
+++ b/src/views/activities-property-view/index.tsx
@@ -1,0 +1,1 @@
+export * from "./activities-property-view";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,9 +1354,9 @@
     headers-utils "^3.0.2"
     strict-event-emitter "^0.2.0"
 
-"@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git#9460ed44db8dff88f686cd8a776b09f1aae02adf":
+"@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#9460ed44db8dff88f686cd8a776b09f1aae02adf"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#5551e2eca7b27a2dfb6438eb45b3319d56ecf52e"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,9 +1354,9 @@
     headers-utils "^3.0.2"
     strict-event-emitter "^0.2.0"
 
-"@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
+"@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git#9460ed44db8dff88f686cd8a776b09f1aae02adf":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#07bc7fbf0735001d9d2a9eb40287c12ba0e4db83"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#9460ed44db8dff88f686cd8a776b09f1aae02adf"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"


### PR DESCRIPTION
We have a requirement to showcase all the activity that takes place when a user updates the patches and areas assignment. The property page on MMH will now have an Activity history button below that will showcase on the changes made to the patches and areas data. Here are some screenshots on how the UI would look like:

Property Page:
![image](https://github.com/LBHackney-IT/mtfh-frontend-activity-history/assets/43747248/454bbef8-9b2f-470f-a554-66821a804472)

Property Activity History:
![image](https://github.com/LBHackney-IT/mtfh-frontend-activity-history/assets/43747248/a1037fc1-4a66-49f9-aa0e-0db86c1a6ff2)

As you can see from the examples above the URL for the property activity history would be the following: `activities/property/:id` `:id ` is the asset PK Guid value