### PR TITLE
Handle payment references updates in tenure activity history

### DIFF
--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -323,6 +323,10 @@ const locale = {
           return format(parseISO(value), "dd/MM/yy");
         },
       },
+      paymentReference: {
+        field: "Payment Reference",
+        output: (value: string): string => value ?? locale.activities.noEntryLabel,
+      },
     },
     tenurePaymentRef: "Tenure payment ref",
   },


### PR DESCRIPTION
Added `paymentReference` field to `locale` so that payment reference changes can be handled in AH. See screenshots below:

Currently in dev:
![image](https://github.com/user-attachments/assets/4b2839e7-9495-41d7-ab38-3d0a21459d5d)

With change:
![image](https://github.com/user-attachments/assets/cc695514-bfc1-4773-8a9e-d23f0e0be3df)

