### PR TITLE
update property patch activity history

### DIFF
--- a/src/components/activity-history-list/activity-history-list.spec.tsx
+++ b/src/components/activity-history-list/activity-history-list.spec.tsx
@@ -25,6 +25,7 @@ import {
   mockRemovedPersonFromTenure,
   mockRemovedPhoneNumber,
   mockStartedProcess,
+  mockUpdatedAssetPatch,
   mockUpdatedDateOfBirth,
   mockUpdatedFirstName,
   mockUpdatedIdentifications,
@@ -774,6 +775,24 @@ test("it should display a row for updated patches and areas", async () => {
     ).resolves.toBeInTheDocument();
     expect(
       screen.findByText(mockUpdatedPatchesAndAreas.newData?.contactDetails?.emailAddress),
+    ).resolves.toBeInTheDocument();
+  });
+});
+test("it should display a row for updated asset patch", async () => {
+  get("/api/activityhistory", {
+    results: [mockUpdatedAssetPatch],
+    paginationDetails: {
+      nextToken: null,
+    },
+  });
+  routeRender(<ActivityHistoryList targetId="123" entityType="property" />);
+
+  await waitFor(() => {
+    expect(
+      screen.findByText(mockUpdatedAssetPatch.oldData?.patchId),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.findByText(mockUpdatedAssetPatch.newData?.patchId),
     ).resolves.toBeInTheDocument();
   });
 });

--- a/src/components/activity-history-list/activity-history-list.tsx
+++ b/src/components/activity-history-list/activity-history-list.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 
 import { ActivityHistoryHeaders } from "./activity-history-headers";
+import { AssetActivityRecord } from "./asset-patch-record";
 import { CautionaryAlertActivityRecord } from "./cautionary-alert-record";
 import { ContactDetailsActivityRecord } from "./contact-details-record";
 import { PatchesAndAreasActivityRecord } from "./patches-and-areas-record";
@@ -138,6 +139,10 @@ export const ActivityHistoryList = ({
                 />
               );
             }
+            if (targetType === "asset") {
+              return <AssetActivityRecord key={index} assetRecord={activity} />;
+            }
+
             return null;
           })}
         </Tbody>

--- a/src/components/activity-history-list/asset-patch-record/asset-patch-record.tsx
+++ b/src/components/activity-history-list/asset-patch-record/asset-patch-record.tsx
@@ -1,0 +1,75 @@
+import React, { ComponentPropsWithoutRef, useMemo } from "react";
+
+import { Activity } from "../../../services/activities";
+import { ActivityRecordItem } from "../activity-record-item";
+import { formattedDate } from "../utils";
+
+import { usePatchOrArea } from "@mtfh/common/lib/api/patch/v1";
+
+import { locale } from "@services";
+
+const { activities } = locale;
+const { entityEdited } = activities;
+
+interface AssetActivityRecordProps
+  extends Omit<ComponentPropsWithoutRef<"div">, "children"> {
+  assetRecord: Activity;
+}
+
+export const AssetActivityRecord = ({
+  assetRecord,
+  ...props
+}: AssetActivityRecordProps): JSX.Element | null => {
+  const {
+    type,
+    targetType,
+    oldData: oldDataActivity,
+    newData: newDataActivty,
+  } = assetRecord;
+
+  const oldData = useMemo(() => oldDataActivity || {}, [oldDataActivity]);
+  const newData = useMemo(() => newDataActivty || {}, [newDataActivty]);
+
+  const date = formattedDate(assetRecord.createdAt);
+  const category = entityEdited(assetRecord.targetType);
+  const edittedBy = assetRecord.authorDetails.fullName;
+  const { data: oldAssetPatch } = usePatchOrArea(oldData?.patchId);
+  const { data: newAssetPatch } = usePatchOrArea(newData?.patchId);
+
+  const activityRecord = useMemo(() => {
+    switch (type) {
+      case "update":
+        return (
+          <UpdatedAssetRecord
+            targetType={targetType}
+            oldAssetPatch={oldAssetPatch?.name}
+            newAssetPatch={newAssetPatch?.name}
+          />
+        );
+      default:
+        return null;
+    }
+  }, [type, targetType, oldAssetPatch, newAssetPatch]);
+  console.log("activityRecord", activityRecord);
+  return (
+    <ActivityRecordItem
+      {...props}
+      date={date}
+      category={category}
+      editDetails={activityRecord}
+      editedBy={edittedBy}
+    />
+  );
+};
+
+const UpdatedAssetRecord = ({
+  targetType,
+  oldAssetPatch,
+  newAssetPatch,
+}: any): JSX.Element => (
+  <>
+    <b>{entityEdited(targetType)}</b>
+    <p>Old Patch Name: {oldAssetPatch}</p>
+    <p>New Patch Name: {newAssetPatch}</p>
+  </>
+);

--- a/src/components/activity-history-list/asset-patch-record/asset-patch-record.tsx
+++ b/src/components/activity-history-list/asset-patch-record/asset-patch-record.tsx
@@ -50,7 +50,6 @@ export const AssetActivityRecord = ({
         return null;
     }
   }, [type, targetType, oldAssetPatch, newAssetPatch]);
-  console.log("activityRecord", activityRecord);
   return (
     <ActivityRecordItem
       {...props}

--- a/src/components/activity-history-list/asset-patch-record/index.ts
+++ b/src/components/activity-history-list/asset-patch-record/index.ts
@@ -1,0 +1,1 @@
+export * from "./asset-patch-record";

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -722,3 +722,26 @@ export const mockUpdatedPatchesAndAreas: Activity = {
   },
   authorDetails: { id: "", fullName: "Jane", email: "email@email.com" },
 };
+
+export const mockUpdatedAssetPatch: Activity = {
+  targetId: "2d13b5cb-baf2-91fd-c231-8c5c2ee9548c",
+  id: "518d2a45-6820-4a7e-9250-3d9f34e0aa23",
+  authorDetails: {
+    id: "",
+    email: "email@email.com",
+    fullName: "Jane",
+  },
+  createdAt: "2025-04-30T08:52:44.3538476Z",
+  newData: {
+    areaId: "3887a798-1e38-4265-9279-bd8097d23b8d",
+    patchId: "7d89aa69-89dd-41e9-bf11-19de8634ce3d",
+  },
+  oldData: {
+    areaId: "8251f11a-84b8-485f-a5b5-6dd9437fbf02",
+    patchId: "f19cc7cd-f64f-4a91-b23a-1b62ab47ae36",
+  },
+  sourceDomain: "Asset",
+  targetType: "asset",
+  timeToLiveForRecordInDays: 0,
+  type: "update",
+};

--- a/src/views/activities-property-view/activities-property-view.tsx
+++ b/src/views/activities-property-view/activities-property-view.tsx
@@ -43,6 +43,7 @@ export const ActivitiesPropertyView = ({
     <div data-testid="property-activities">
       <PropertyInformation asset={asset} />
       <ActivityHistoryList targetId={asset.patchId} entityType={entityType} />
+      <ActivityHistoryList targetId={asset.id} entityType={entityType} />
       <Button as={RouterLink} to={`/property/${assetPK}`} variant="secondary">
         {closeButton}
       </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,7 +1356,7 @@
 
 "@mtfh/common@https://github.com/LBHackney-IT/mtfh-frontend-common.git":
   version "0.0.1"
-  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#5551e2eca7b27a2dfb6438eb45b3319d56ecf52e"
+  resolved "https://github.com/LBHackney-IT/mtfh-frontend-common.git#fb0ac51bed2d71d05312b21c969b64584e362954"
   dependencies:
     "@babel/preset-react" "^7.13.13"
     "@radix-ui/react-polymorphic" "^0.0.12"


### PR DESCRIPTION
Every time the patch name is edited, you can view the patch name change in Activity history, here's example below of how it looks:

![image](https://github.com/user-attachments/assets/dae0fc39-0933-4fb7-b646-cc2332654204)
